### PR TITLE
Fix initial loading

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -19,7 +19,7 @@ class App extends React.Component {
 export default connect(
     state => {
         return {
-            // user: state.default.user,
+            user: state.user.user,
             loading: state.asyncInitialState.loading,
         }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import {createStore, combineReducers, applyMiddleware} from 'redux';
-import reducers from './reducers';
+import * as reducers from './reducers';
 import * as asyncInitialState from 'redux-async-initial-state';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -22,9 +22,16 @@ const loadStore = () => {
     return new Promise(resolve => {
         fetch('https://jsonplaceholder.typicode.com/users/1')
             .then(response => {
-                return response.json()
+                return response.json();
             })
-            .then(resolve);
+            .then(user => {
+                resolve({
+                    user: {
+                        user: user,
+                        isFetching: false
+                    }
+                });
+            });
     });
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,3 @@
 import {combineReducers} from 'redux'
 
-import user from './user'
-
-
-export default combineReducers({
-    user,
-})
+export { default as user } from './user'


### PR DESCRIPTION
Hey!

So, here are few things about your example:

1) You did `combineReducers` twice: one time in `reducers/index` and another in `main.js`. So, if you do:

``` js
import reducers from './reducers';
console.log({...reducers});
```

You will see that you don't have your `user` key, that you should have from reducers

2) Shape of your store is (using json schema):

``` json
{
  "user": {
    "isFetching": "boolean",
    "user": "object"
  },
  "asyncInitialState": {
    "loaded": "boolean",
    "loading": "boolean",
    "error": "boolean"
  }
}
```

In your example you are fetching only user object, that should be placed in `user.user` in your store, so in this case you can't resolve promise in `loadStore` with your `user` object, because redux-async-initial-state will try to replace whole your store to this object.  Instead, you have to resolve it with: 

``` js
{
    user: {
        user: user,
        isFetching: false
    }
}
```

Let me know if it helps!
